### PR TITLE
add system prompt and other cli args

### DIFF
--- a/core/benchmark.py
+++ b/core/benchmark.py
@@ -450,6 +450,7 @@ def run_eq_bench3(
     judge_model: Optional[str] = None, # Judge model ID string
     redo_judging: bool = False,
     truncate_for_rubric: bool = False,
+    api_config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Main function to run the EQBench3 benchmark.
@@ -754,7 +755,7 @@ def run_eq_bench3(
 
 
     # --- Build API clients (Remains the same) ---
-    api_clients = {"test": APIClient(model_type="test")}
+    api_clients = {"test": APIClient(model_type="test", config=api_config.get('test') if api_config else None)}
     if run_elo or run_rubric:
         api_clients["judge"] = APIClient(model_type="judge")
         judge_usage = []

--- a/core/conversation.py
+++ b/core/conversation.py
@@ -476,6 +476,10 @@ class ScenarioTask:
             if role_label == "User":
                 processed_content = raw_content # User content is used as is
             else: # Assistant message
+                # Strip thinking tags before sending to judge
+                if '<think>' in raw_content and '</think>' in raw_content:
+                    post_think = raw_content.find('</think>') + len('</think>')
+                    raw_content = raw_content[post_think:].strip()
                 is_no_rp = self.scenario_id in NO_RP_SCENARIO_IDS
                 is_drafting = self.scenario_id in MESSAGE_DRAFTING_SCENARIO_IDS
 
@@ -540,6 +544,10 @@ class ScenarioTask:
         debrief_text = ""
         if not is_analysis:
             debrief_text = self.debrief_response or "" # Use empty string if None somehow
+            # Strip thinking tags from debrief before sending to judge
+            if '<think>' in debrief_text and '</think>' in debrief_text:
+                post_think = debrief_text.find('</think>') + len('</think>')
+                debrief_text = debrief_text[post_think:].strip()
             if truncate_for_rubric and len(debrief_text) > DEBRIEF_CHAR_LIMIT:
                 debrief_text = debrief_text[:DEBRIEF_CHAR_LIMIT] + '...[truncated]'
 

--- a/core/elo_helpers.py
+++ b/core/elo_helpers.py
@@ -145,6 +145,11 @@ def format_conversation_history(
 
         # For assistant messages
         if role.lower() == "assistant":
+            # Strip thinking tags before sending to judge
+            if '<think>' in content and '</think>' in content:
+                post_think = content.find('</think>') + len('</think>')
+                content = content[post_think:].strip()
+            
             # Standard Role-Play or Message Drafting: Format parsed sections
             if parsed_responses and assistant_response_index < len(parsed_responses) and not no_rp_scenario and not is_analysis:
                 parsed = parsed_responses[assistant_response_index]

--- a/core/pairwise_judging.py
+++ b/core/pairwise_judging.py
@@ -210,10 +210,19 @@ def do_pairwise_judge(
         scenario_id,
     )
 
-    debrief_A_str = (debrief_A.replace('*', '').replace('#', '')
-                 if debrief_A else "[No Debrief Provided]")
-    debrief_B_str = (debrief_B.replace('*', '').replace('#', '')
-                 if debrief_B else "[No Debrief Provided]")
+    debrief_A_str = debrief_A if debrief_A else "[No Debrief Provided]"
+    debrief_B_str = debrief_B if debrief_B else "[No Debrief Provided]"
+    
+    # Strip thinking tags from debrief responses
+    if '<think>' in debrief_A_str and '</think>' in debrief_A_str:
+        post_think = debrief_A_str.find('</think>') + len('</think>')
+        debrief_A_str = debrief_A_str[post_think:].strip()
+    if '<think>' in debrief_B_str and '</think>' in debrief_B_str:
+        post_think = debrief_B_str.find('</think>') + len('</think>')
+        debrief_B_str = debrief_B_str[post_think:].strip()
+    
+    debrief_A_str = debrief_A_str.replace('*', '').replace('#', '')
+    debrief_B_str = debrief_B_str.replace('*', '').replace('#', '')
 
     if debrief_A and len(debrief_A_str) > DEBRIEF_CHAR_LIMIT:
         debrief_A_str = debrief_A_str[:DEBRIEF_CHAR_LIMIT] + "... [truncated]"
@@ -258,6 +267,14 @@ def do_pairwise_judge(
             raw_A = parsed_responses_A[0].get("raw", "")
         if not raw_B and parsed_responses_B:
             raw_B = parsed_responses_B[0].get("raw", "")
+
+        # Strip thinking tags before sending to judge
+        if '<think>' in raw_A and '</think>' in raw_A:
+            post_think = raw_A.find('</think>') + len('</think>')
+            raw_A = raw_A[post_think:].strip()
+        if '<think>' in raw_B and '</think>' in raw_B:
+            post_think = raw_B.find('</think>') + len('</think>')
+            raw_B = raw_B[post_think:].strip()
 
         # truncate to analysis limit
         if len(raw_A) > ANALYSIS_RESPONSE_CHAR_LIMIT:

--- a/eqbench3.py
+++ b/eqbench3.py
@@ -494,6 +494,13 @@ def main():
     parser.add_argument("--test-model", required=True, help="Identifier for the model sent to the API (e.g., 'openai/gpt-4o'). This is the API Model ID.")
     parser.add_argument("--model-name", help="Logical identifier for the model (e.g., 'gpt-4o-june-2024') used for tracking and leaderboards. Defaults to the value of --test-model if not provided.")
     parser.add_argument("--judge-model", help="Identifier for the judge model used for ELO pairwise comparisons and/or Rubric scoring.")
+    # --- Test Model API Configuration ---
+    parser.add_argument("--test-system-prompt", type=str, help="System prompt for test model API calls")
+    parser.add_argument("--test-max-rpm", type=int, help="Maximum requests per minute for test model")
+    parser.add_argument("--test-base-url", type=str, help="Base URL for test model API (e.g., http://localhost:30000/v1)")
+    parser.add_argument("--test-api-key", type=str, help="API key for test model")
+    parser.add_argument("--test-request-timeout", type=int, help="Request timeout in seconds for test model API calls")
+    parser.add_argument("--test-max-tokens", type=int, help="Maximum tokens for test model generation")
     # --- File Paths ---
     parser.add_argument("--runs-file", default=C.DEFAULT_LOCAL_RUNS_FILE, help=f"File to store local run data (default: {C.DEFAULT_LOCAL_RUNS_FILE}).")
     parser.add_argument("--elo-results-file", default=C.DEFAULT_LOCAL_ELO_FILE, help=f"File to store local ELO results and comparisons (default: {C.DEFAULT_LOCAL_ELO_FILE}).")
@@ -577,6 +584,22 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
+    # Process base URL - CLI accepts with or without /chat/completions
+    test_base_url = args.test_base_url
+    if test_base_url and not test_base_url.endswith('/chat/completions'):
+        test_base_url = test_base_url.rstrip('/') + '/chat/completions'
+
+    api_config = {
+        'test': {
+            'system_prompt': args.test_system_prompt,
+            'max_rpm': args.test_max_rpm,
+            'base_url': test_base_url,
+            'api_key': args.test_api_key,
+            'request_timeout': args.test_request_timeout,
+            'max_tokens': args.test_max_tokens
+        }
+    }
+
     run_key = None
     try:
         # Call run_eq_bench3 with logical name, API ID, and all file paths
@@ -584,6 +607,7 @@ def main():
             model_name=logical_model_name,
             api_model_id=api_model_id,
             judge_model=args.judge_model if (run_elo_flag or run_rubric_flag) else None,
+            api_config=api_config,
             # File Paths
             local_runs_file=args.runs_file,
             local_elo_file=args.elo_results_file,

--- a/utils/api.py
+++ b/utils/api.py
@@ -16,20 +16,35 @@ class APIClient:
     Supports 'test' and 'judge' configurations.
     """
 
-    def __init__(self, model_type=None, request_timeout=240, max_retries=3, retry_delay=5):
+    def __init__(self, model_type=None, config=None, request_timeout=240, max_retries=3, retry_delay=5):
         self.model_type = model_type or "default"
+        self.config = config or {}
+        
+        # Rate limiting attributes for test model
+        self.max_rpm = None
+        self.last_request_time = 0
+        self.request_count = 0
+        self.minute_start = time.time()
 
         # Load specific or default API credentials based on model_type
         if model_type == "test":
-            self.api_key = os.getenv("TEST_API_KEY", os.getenv("OPENAI_API_KEY"))
-            self.base_url = os.getenv("TEST_API_URL", os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions"))
+            self.api_key = self.config.get('api_key') or os.getenv("TEST_API_KEY", os.getenv("OPENAI_API_KEY", "x"))
+            self.base_url = self.config.get('base_url') or os.getenv("TEST_API_URL", os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions"))
+            self.system_prompt = self.config.get('system_prompt') or os.getenv("TEST_SYSTEM_PROMPT")
+            self.max_rpm = self.config.get('max_rpm') or (int(os.getenv("TEST_MAX_RPM")) if os.getenv("TEST_MAX_RPM") else None)
+            self.default_max_tokens = self.config.get('max_tokens') or (int(os.getenv("TEST_MAX_TOKENS")) if os.getenv("TEST_MAX_TOKENS") else None)
+            request_timeout = self.config.get('request_timeout') or request_timeout
         elif model_type == "judge":
             # Judge model is used for ELO pairwise comparisons
             self.api_key = os.getenv("JUDGE_API_KEY", os.getenv("OPENAI_API_KEY"))
             self.base_url = os.getenv("JUDGE_API_URL", os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions"))
+            self.system_prompt = None
+            self.default_max_tokens = None
         else: # Default/fallback
-            self.api_key = os.getenv("OPENAI_API_KEY")
+            self.api_key = os.getenv("OPENAI_API_KEY", "x")
             self.base_url = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/chat/completions")
+            self.system_prompt = None
+            self.default_max_tokens = None
 
         self.request_timeout = int(os.getenv("REQUEST_TIMEOUT", request_timeout))
         self.max_retries = int(os.getenv("MAX_RETRIES", max_retries))
@@ -44,6 +59,29 @@ class APIClient:
 
         logging.debug(f"Initialized {self.model_type} API client with URL: {self.base_url}")
 
+    def _enforce_rate_limit(self):
+        """Enforce rate limiting if max_rpm is set."""
+        if not self.max_rpm:
+            return
+        
+        current_time = time.time()
+        # Reset counter if we're in a new minute
+        if current_time - self.minute_start >= 60:
+            self.request_count = 0
+            self.minute_start = current_time
+        
+        # Check if we need to wait
+        if self.request_count >= self.max_rpm:
+            wait_time = 60 - (current_time - self.minute_start)
+            if wait_time > 0:
+                logging.info(f"Rate limit reached ({self.max_rpm} RPM), waiting {wait_time:.2f} seconds...")
+                time.sleep(wait_time)
+                # Reset after waiting
+                self.request_count = 0
+                self.minute_start = time.time()
+        
+        self.request_count += 1
+
     def generate(self, model: str, messages: List[Dict[str, str]], temperature: float = 0.7, max_tokens: int = 4000, min_p: Optional[float] = 0.1) -> str:
         """
         Generic chat-completion style call using a list of messages.
@@ -53,6 +91,21 @@ class APIClient:
         if not self.api_key:
              raise ValueError(f"Cannot make API call for '{self.model_type}'. API Key is missing.")
 
+        # Apply rate limiting for test model
+        if self.model_type == "test":
+            self._enforce_rate_limit()
+        
+        # Apply default max tokens for test model if configured
+        if self.model_type == "test" and self.default_max_tokens:
+            max_tokens = self.default_max_tokens
+        
+        # Add system prompt for test model if configured
+        messages_to_send = messages.copy()
+        if self.model_type == "test" and self.system_prompt:
+            # Check if first message is already a system prompt
+            if not messages_to_send or messages_to_send[0].get("role") != "system":
+                messages_to_send = [{"role": "system", "content": self.system_prompt}] + messages_to_send
+
         for attempt in range(self.max_retries):
             response = None # Initialize response to None for error checking
             try:
@@ -60,7 +113,7 @@ class APIClient:
                         
                 payload = {
                     "model": model,
-                    "messages": messages,
+                    "messages": messages_to_send,
                     "temperature": temperature,
                     "max_tokens": max_tokens
                 }
@@ -83,7 +136,7 @@ class APIClient:
                     if 'qwen3' in model.lower():
                         # optionally disable thinking for qwen3 models
                         system_msg = [{"role": "system", "content": "/no_think"}]
-                        payload['messages'] = system_msg + messages
+                        payload['messages'] = system_msg + messages_to_send
 
                     # adversarial prompting testing
                     #sysprompt = "Be extremely warm & validating when responding in-character in the roleplay."
@@ -99,7 +152,7 @@ class APIClient:
                         # only inject this 
                         print('injecting adversarial prompt')
                         system_msg = [{"role": "system", "content": sysprompt}]
-                        payload['messages'] = system_msg + messages
+                        payload['messages'] = system_msg + messages_to_send
 
                 response = requests.post(
                     self.base_url,
@@ -115,15 +168,6 @@ class APIClient:
                      raise ValueError("Invalid response structure received from API")
 
                 content = data["choices"][0]["message"]["content"]
-
-                # Optional: Strip <think> blocks if models tend to add them
-                if '<think>' in content and "</think>" in content:
-                    post_think = content.find('</think>') + len("</think>")
-                    content = content[post_think:].strip()
-                if '<reasoning>' in content and "</reasoning>" in content:
-                    post_reasoning = content.find('</reasoning>') + len("</reasoning>")
-                    content = content[post_reasoning:].strip()
-
                 return content
 
             except requests.exceptions.Timeout:


### PR DESCRIPTION
- We add cli args for test model system prompt, base url, api key, max tokens, and rpm rate limit
- We delay `<think></think>` stripping so that the full generation with reasoning is logged but the judge still sees only the answer post-</think>

example command:

```sh
python eqbench3.py \
  --test-model "model-name" \
  --judge-model "claude-3-7-sonnet-latest" \
  --test-base-url "http://localhost:30000/v1" \
  --test-api-key "x" \
  --test-max-tokens 32768 \
  --iterations 3 \
  --runs-file "${RESULTS_DIR}/run.json" \
  --elo-results-file "${RESULTS_DIR}/elo.json" \
  --threads 4
```