### PR TITLE
Fix crash when reasoning models return null content via OpenRouter

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -136,6 +136,20 @@ class APIClient:
 
                 content = data["choices"][0]["message"]["content"]
 
+                # Reasoning models via OpenRouter may return content as None
+                # with the actual output in the reasoning field
+                if content is None:
+                    message = data["choices"][0]["message"]
+                    content = message.get("reasoning_content") or message.get("reasoning") or ""
+                    if content:
+                        logging.info(f"Model {model}: content was None, extracted response from reasoning field")
+                    else:
+                        logging.warning(
+                            f"Model {model}: API returned content=None with no reasoning fallback. "
+                            f"finish_reason={data['choices'][0].get('finish_reason', 'unknown')}. "
+                            f"Returning empty string."
+                        )
+
                 # Optional: Strip <think> blocks if models tend to add them
                 if '<think>' in content and "</think>" in content:
                     post_think = content.find('</think>') + len("</think>")


### PR DESCRIPTION
## Summary
- Reasoning models (MiniMax M2.7, MiMo-V2-Pro, Step 3.5 Flash, DeepSeek-R1) via OpenRouter can return `content: null` when chain-of-thought consumes the token budget, with actual output in the `reasoning` or `reasoning_content` field
- This caused a `TypeError: argument of type 'NoneType' is not a container or iterable` crash on the `<think>` block stripping logic in `api.py`
- Now extracts from `reasoning_content`/`reasoning` fields before falling back to empty string
- Adds logging: INFO when reasoning field extraction succeeds, WARNING when content is genuinely empty (with `finish_reason` for diagnosis)

## Reproduction
Run any reasoning model via OpenRouter where the model's chain-of-thought is verbose enough to consume most of the `max_tokens` budget:
```
python eqbench3.py --test-model minimax/minimax-m2.7 --judge-model anthropic/claude-sonnet-4.6 --no-elo --iterations 1
```

## Test plan
- [x] Verified fix prevents TypeError crash with MiniMax M2.7 (completed full 45-scenario benchmark run)
- [x] Verified non-reasoning models (GPT-5.4 Mini, Claude Haiku 4.5) unaffected
- [x] Verified reasoning models that return content normally (MiMo, Step) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)