### PR TITLE
feat: add targeted scenario and rubric repair modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ You interact with the main script [`eqbench3.py`](./eqbench3.py). It orchestrate
 | `--no-rubric`                      | If set, skip the rubric scoring step.                                                                                                   |
 | `--ignore-canonical`               | If set, do not load or use default canonical leaderboard files. Runs will be based on local files only.                                  |
 | `--redo-rubric-judging`            | Reset tasks’ rubric status so that rubric scoring is done again.                                                                        |
+| `--repair-rubric`                  | With `--run-id`, rerun only interrupted, failed, or score-missing rubric tasks. Cannot be combined with `--redo-rubric-judging`.        |
+| `--repair-scenario`                | With `--run-id`, rerun only interrupted or failed scenario and debrief tasks. Combine with `--repair-rubric` to repair both phases.   |
 | `--reset-model`                    | Wipes all local data (runs & ELO comparisons) pertaining to `--model-name` before starting.                                             |
 
 Run `python eqbench3.py --help` for the full usage.

--- a/core/benchmark.py
+++ b/core/benchmark.py
@@ -449,6 +449,8 @@ def run_eq_bench3(
     run_rubric: bool = True,
     judge_model: Optional[str] = None, # Judge model ID string
     redo_judging: bool = False,
+    repair_scenarios: bool = False,
+    repair_rubric: bool = False,
     truncate_for_rubric: bool = False,
 ) -> str:
     """
@@ -770,6 +772,7 @@ def run_eq_bench3(
     run_data_for_tasks = merged_runs.get(run_key, {})
     existing_tasks_data = run_data_for_tasks.get("scenario_tasks", {})
     tasks_to_process: List[ScenarioTask] = []
+    recovered_tasks: List[ScenarioTask] = []
 
     total_tasks_expected = len(scenarios) * iterations
     logging.info(f"Preparing {total_tasks_expected} total tasks ({len(scenarios)} scenarios x {iterations} iterations)...")
@@ -810,6 +813,14 @@ def run_eq_bench3(
                         if task_obj.iteration_index != i:
                             logging.warning(f"Mismatch iteration index in loaded task data for {scenario_id} (expected {i}, got {task_obj.iteration_index}). Resetting.")
                             task_obj.iteration_index = i
+                        if (repair_scenarios or repair_rubric) and task_obj.recover_for_resume(
+                            repair_scenario=repair_scenarios,
+                            repair_rubric=repair_rubric,
+                            valid_rubric_criteria=set(
+                                analysis_rubric_criteria if is_analysis else standard_rubric_criteria
+                            ),
+                        ):
+                            recovered_tasks.append(task_obj)
                         logging.debug(f"Resuming task: Scenario {scenario_id}, Iteration {i}, Status: {task_obj.status}")
                     except Exception as e:
                         logging.error(f"Failed to load task from dict for scenario={scenario_id}, iter={i}: {e}. Creating new task.", exc_info=True)
@@ -848,13 +859,32 @@ def run_eq_bench3(
     )
     save_thread.start()
     logging.info("Save worker thread started.")
+    for task in recovered_tasks:
+        task._save_progress(save_queue, run_key)
+    if recovered_tasks:
+        logging.info(
+            "Persisted recovery state for %s interrupted or failed task(s).",
+            len(recovered_tasks),
+        )
+    recovered_task_keys = {
+        (task.iteration_index, task.scenario_id)
+        for task in recovered_tasks
+    }
 
     # --- Execute Tasks (Remains largely the same, save worker handles target file) ---
     tasks_completed_this_run = 0 # Tracks tasks fully completed (incl. rubric if enabled)
 
     try:
         # 1. Run scenario steps
-        tasks_needing_scenario = [t for t in tasks_to_process if t.status in ["initialized", "error"]]
+        tasks_needing_scenario = []
+        if repair_scenarios or repair_rubric:
+            tasks_needing_scenario = [
+                t for t in tasks_to_process
+                if (t.iteration_index, t.scenario_id) in recovered_task_keys
+                and t.status == "initialized"
+            ]
+        else:
+            tasks_needing_scenario = [t for t in tasks_to_process if t.status in ["initialized", "error"]]
         if tasks_needing_scenario:
             logging.info(f"Running scenario simulation for {len(tasks_needing_scenario)} tasks...")
             with ThreadPoolExecutor(max_workers=num_threads, thread_name_prefix="ScenarioRun") as executor:
@@ -879,7 +909,19 @@ def run_eq_bench3(
 
 
         # 2. Run debrief steps (Skip for Analysis tasks)
-        tasks_needing_debrief = [t for t in tasks_to_process if t.status == "scenario_completed" and t.scenario_id not in C.ANALYSIS_SCENARIO_IDS]
+        tasks_needing_debrief = []
+        if repair_scenarios or repair_rubric:
+            tasks_needing_debrief = [
+                t for t in tasks_to_process
+                if (t.iteration_index, t.scenario_id) in recovered_task_keys
+                and t.status == "scenario_completed"
+                and t.scenario_id not in C.ANALYSIS_SCENARIO_IDS
+            ]
+        else:
+            tasks_needing_debrief = [
+                t for t in tasks_to_process
+                if t.status == "scenario_completed" and t.scenario_id not in C.ANALYSIS_SCENARIO_IDS
+            ]
         if tasks_needing_debrief:
             logging.info(f"Running debrief for {len(tasks_needing_debrief)} non-analysis tasks...")
             with ThreadPoolExecutor(max_workers=num_threads, thread_name_prefix="DebriefRun") as executor:
@@ -906,17 +948,41 @@ def run_eq_bench3(
         if run_rubric:
             # Standard/Drafting tasks need rubric if status is 'completed'
             # Analysis tasks need rubric if status is 'scenario_completed'
-            tasks_needing_rubric = [
+            rubric_ready_tasks = [
                 t for t in tasks_to_process
                 if (
+                    not (repair_scenarios or repair_rubric)
+                    or redo_judging
+                    or (
+                        repair_rubric
+                        and (t.iteration_index, t.scenario_id) in recovered_task_keys
+                    )
+                ) and (
                     (
                         t.scenario_id in C.ANALYSIS_SCENARIO_IDS and t.status == "scenario_completed"
                     ) or (
                         t.scenario_id not in C.ANALYSIS_SCENARIO_IDS and t.status == "completed"
                     )
                 )
-                and _task_has_all_expected_responses(t)          # <<< new guard
             ]
+            tasks_needing_rubric = [
+                t for t in rubric_ready_tasks
+                if _task_has_all_expected_responses(t)
+            ]
+            incomplete_rubric_tasks = [
+                t for t in rubric_ready_tasks
+                if not _task_has_all_expected_responses(t)
+            ]
+            for task in incomplete_rubric_tasks:
+                task.status = "error"
+                task.error = "Rubric Scoring Error: Task output incomplete; rubric scoring skipped."
+                task.rubric_run_error = "Task output incomplete"
+                task._save_progress(save_queue, run_key)
+                logging.warning(
+                    "Skipping rubric scoring for incomplete task %s (Iter %s).",
+                    task.scenario_id,
+                    task.iteration_index,
+                )
 
             if tasks_needing_rubric:
                 logging.info(f"Running rubric scoring for {len(tasks_needing_rubric)} tasks using judge model '{judge_model}' (Truncation: {truncate_for_rubric})...")

--- a/core/conversation.py
+++ b/core/conversation.py
@@ -7,7 +7,7 @@ import time
 import logging
 import re
 import json # For parsing rubric scores
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Set, Tuple
 import queue
 from utils.constants import (
     NO_RP_SCENARIO_IDS,
@@ -84,6 +84,75 @@ class ScenarioTask:
              logging.warning("Save queue is None, cannot save progress.")
         elif not run_key:
              logging.warning("Run key is None, cannot save progress.")
+
+    def recover_for_resume(
+        self,
+        repair_scenario: bool = False,
+        repair_rubric: bool = False,
+        valid_rubric_criteria: Optional[Set[str]] = None,
+    ) -> bool:
+        """
+        Restore requested interrupted or failed task phases for a targeted repair.
+
+        Completed phase outputs are deliberately preserved. This lets a resumed
+        run retry only the failed API call instead of regenerating the scenario
+        or debrief unnecessarily.
+        """
+        is_analysis = self.scenario_id in ANALYSIS_SCENARIO_IDS
+        rubric_ready_status = "scenario_completed" if is_analysis else "completed"
+        previous_status = self.status
+        recovered_status = None
+
+        has_numeric_rubric_score = isinstance(self.rubric_scores, dict) and any(
+            isinstance(score, (int, float))
+            and (valid_rubric_criteria is None or criterion in valid_rubric_criteria)
+            for criterion, score in self.rubric_scores.items()
+        )
+
+        if self.status == "running_scenario" and repair_scenario:
+            recovered_status = "initialized"
+        elif self.status == "running_debrief" and repair_scenario:
+            recovered_status = "completed" if self.debrief_response is not None else "scenario_completed"
+        elif self.status == "running_rubric_scoring" and repair_rubric:
+            recovered_status = rubric_ready_status
+        elif self.status == "error":
+            if self.rubric_run_error:
+                if repair_rubric:
+                    recovered_status = rubric_ready_status
+            elif self.debrief_run_error:
+                if repair_scenario:
+                    recovered_status = "scenario_completed"
+            elif repair_scenario:
+                # Includes explicit scenario errors and legacy errors without
+                # a phase-specific marker. run_scenario resumes from any
+                # successfully persisted turns in conversation_history.
+                recovered_status = "initialized"
+        elif self.status == "rubric_scored" and repair_rubric and not has_numeric_rubric_score:
+            recovered_status = rubric_ready_status
+
+        if recovered_status is None:
+            return False
+
+        self.status = recovered_status
+        self.error = None
+        if previous_status == "rubric_scored":
+            self.rubric_scores = None
+        if previous_status == "error":
+            if self.rubric_run_error:
+                self.rubric_run_error = None
+            elif self.debrief_run_error:
+                self.debrief_run_error = None
+            else:
+                self.scenario_run_error = None
+
+        logging.info(
+            "Recovered task %s (Iter %s) from '%s' to '%s' for resume.",
+            self.scenario_id,
+            self.iteration_index,
+            previous_status,
+            recovered_status,
+        )
+        return True
 
 
     def _parse_response(self, response: str) -> Dict[str, str]:

--- a/eqbench3.py
+++ b/eqbench3.py
@@ -606,6 +606,18 @@ def main():
     parser.add_argument("--redo-rubric-judging", action="store_true", default=False,
                         help="If set, tasks in the local runs file that have completed rubric scoring will be reset so the rubric step is re-run.")
     parser.add_argument(
+        "--repair-rubric",
+        action="store_true",
+        default=False,
+        help="Repair only interrupted, failed, or score-missing rubric tasks in the resumed run.",
+    )
+    parser.add_argument(
+        "--repair-scenario",
+        action="store_true",
+        default=False,
+        help="Repair only interrupted or failed scenario and debrief tasks in the resumed run.",
+    )
+    parser.add_argument(
         "--reset-model",
         action="store_true",
         default=False,
@@ -675,6 +687,13 @@ def main():
     run_elo_flag = not args.no_elo
     run_rubric_flag = not args.no_rubric
 
+    if (args.repair_rubric or args.repair_scenario) and not args.run_id:
+        parser.error("--repair-rubric and --repair-scenario require --run-id to target an existing run.")
+    if args.repair_rubric and args.no_rubric:
+        parser.error("--repair-rubric cannot be used with --no-rubric.")
+    if args.repair_rubric and args.redo_rubric_judging:
+        parser.error("--repair-rubric and --redo-rubric-judging are mutually exclusive.")
+
     if (run_elo_flag or run_rubric_flag) and not args.judge_model:
         parser.error("--judge-model is required unless both --no-elo and --no-rubric are specified.")
         sys.exit(1)
@@ -704,6 +723,8 @@ def main():
             run_elo=run_elo_flag,
             run_rubric=run_rubric_flag,
             redo_judging=args.redo_rubric_judging,
+            repair_scenarios=args.repair_scenario,
+            repair_rubric=args.repair_rubric,
             truncate_for_rubric=False, # Hardcoded for now, could be arg
         )
 

--- a/tests/test_task_resume_recovery.py
+++ b/tests/test_task_resume_recovery.py
@@ -1,0 +1,128 @@
+import unittest
+
+from core.conversation import ScenarioTask
+
+
+def make_task(scenario_id: str = "001") -> ScenarioTask:
+    return ScenarioTask(
+        scenario_id=scenario_id,
+        prompts=["Prompt one"],
+        debrief_prompt=None if scenario_id == "401" else "Debrief prompt",
+        iteration_index=1,
+        test_model="test-model",
+    )
+
+
+class ScenarioTaskResumeRecoveryTests(unittest.TestCase):
+    def test_rubric_error_retries_only_rubric_phase(self):
+        task = make_task()
+        task.status = "error"
+        task.conversation_history = [{"role": "assistant", "content": "completed response"}]
+        task.debrief_response = "completed debrief"
+        task.rubric_run_error = "Judge API timed out"
+        task.error = "Rubric Scoring Error: API call failed"
+
+        self.assertTrue(task.recover_for_resume(repair_rubric=True))
+
+        self.assertEqual(task.status, "completed")
+        self.assertEqual(task.conversation_history[0]["content"], "completed response")
+        self.assertEqual(task.debrief_response, "completed debrief")
+        self.assertIsNone(task.rubric_run_error)
+        self.assertIsNone(task.error)
+
+    def test_debrief_error_reuses_completed_scenario(self):
+        task = make_task()
+        task.status = "error"
+        task.conversation_history = [{"role": "assistant", "content": "completed response"}]
+        task.debrief_run_error = "Test API timed out"
+
+        self.assertTrue(task.recover_for_resume(repair_scenario=True))
+
+        self.assertEqual(task.status, "scenario_completed")
+        self.assertEqual(task.conversation_history[0]["content"], "completed response")
+        self.assertIsNone(task.debrief_response)
+
+    def test_scenario_error_preserves_completed_turns(self):
+        task = make_task()
+        task.status = "error"
+        task.conversation_history = [
+            {"role": "user", "content": "Prompt one"},
+            {"role": "assistant", "content": "first completed turn"},
+        ]
+        task.parsed_responses = [{"raw": "first completed turn"}]
+        task.scenario_run_error = "Test API timed out"
+
+        self.assertTrue(task.recover_for_resume(repair_scenario=True))
+
+        self.assertEqual(task.status, "initialized")
+        self.assertEqual(task.conversation_history[1]["content"], "first completed turn")
+        self.assertEqual(task.parsed_responses[0]["raw"], "first completed turn")
+
+    def test_interrupted_rubric_returns_to_analysis_rubric_ready_state(self):
+        task = make_task("401")
+        task.status = "running_rubric_scoring"
+        task.conversation_history = [{"role": "assistant", "content": "analysis response"}]
+
+        self.assertTrue(task.recover_for_resume(repair_rubric=True))
+
+        self.assertEqual(task.status, "scenario_completed")
+        self.assertEqual(task.conversation_history[0]["content"], "analysis response")
+
+    def test_interrupted_debrief_with_saved_response_is_completed(self):
+        task = make_task()
+        task.status = "running_debrief"
+        task.conversation_history = [{"role": "assistant", "content": "completed response"}]
+        task.debrief_response = "saved debrief"
+
+        self.assertTrue(task.recover_for_resume(repair_scenario=True))
+
+        self.assertEqual(task.status, "completed")
+        self.assertEqual(task.debrief_response, "saved debrief")
+
+    def test_repair_rubric_recovers_scored_task_without_numeric_scores(self):
+        task = make_task()
+        task.status = "rubric_scored"
+        task.rubric_scores = {"judge_note": "No score returned"}
+        task.raw_rubric_judge_text = '{"judge_note": "No score returned"}'
+
+        self.assertTrue(task.recover_for_resume(repair_rubric=True))
+
+        self.assertEqual(task.status, "completed")
+        self.assertIsNone(task.rubric_scores)
+
+    def test_repair_rubric_requires_an_allowed_numeric_score(self):
+        task = make_task()
+        task.status = "rubric_scored"
+        task.rubric_scores = {"unexpected_numeric_field": 1.0}
+
+        self.assertTrue(
+            task.recover_for_resume(
+                repair_rubric=True,
+                valid_rubric_criteria={"overall_eq"},
+            )
+        )
+
+        self.assertEqual(task.status, "completed")
+        self.assertIsNone(task.rubric_scores)
+
+    def test_repair_rubric_does_not_restart_scenario_errors(self):
+        task = make_task()
+        task.status = "error"
+        task.scenario_run_error = "Test API timed out"
+
+        self.assertFalse(task.recover_for_resume(repair_rubric=True))
+        self.assertEqual(task.status, "error")
+
+    def test_completed_rubric_is_not_changed(self):
+        task = make_task()
+        task.status = "rubric_scored"
+        task.rubric_scores = {"overall_eq": 80.0}
+
+        self.assertFalse(task.recover_for_resume(repair_rubric=True))
+
+        self.assertEqual(task.status, "rubric_scored")
+        self.assertEqual(task.rubric_scores, {"overall_eq": 80.0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `--repair-scenario` to rerun only interrupted or failed scenario and debrief steps
- Add `--repair-rubric` to rerun only failed, interrupted, or score-missing rubric judgments
- Validate persisted rubric scores against the active criteria before treating a task as complete
- Support scenario repair followed by full rubric rejudging with `--redo-rubric-judging`
- Add recovery-state tests and document the new CLI options

## Validation
- `python -m unittest discover -s tests -v`
- `python eqbench3.py --help`
- Repaired run `5ae4a909_churu` with `--repair-scenario --repair-rubric --no-elo`; completed successfully